### PR TITLE
Fix parsing models from GTA III and VC

### DIFF
--- a/src/renderware/dff/DffParser.ts
+++ b/src/renderware/dff/DffParser.ts
@@ -305,7 +305,8 @@ export class DffParser extends RwFile {
         for (let i = 0; i < geometricObjectCount; i++) {
             this.readSectionHeader();
             this.readSectionHeader();
-            const geometryData = this.readGeometry(header.versionNumber);
+            const versionNumber = RwVersion.unpackVersion(header.versionNumber);
+            const geometryData = this.readGeometry(versionNumber);
             geometries.push(geometryData);
         }
 

--- a/src/renderware/utils/RwVersion.ts
+++ b/src/renderware/utils/RwVersion.ts
@@ -4,6 +4,7 @@
 export default class RwVersion {
     static readonly versions: { [versionNumber: number]: string } = {
         0x31000: 'RenderWare 3.1.0.0 (III on PS2)',
+        0x32000: 'RenderWare 3.2.0.0 (III on PC)',
         0x33002: 'RenderWare 3.3.0.2 (III on PC, VC on PS2)',
         0x34003: 'RenderWare 3.4.0.3 (VC on PC)',
         0x34005: 'RenderWare 3.4.0.5 (III on PS2, VC on Android/PC)',


### PR DESCRIPTION
A minor version comparison bug was fixed, and the missing RwVersion used in GTA 3 was added.